### PR TITLE
Write completion timestamp when closing orders

### DIFF
--- a/app/api/orders/[id]/close/route.ts
+++ b/app/api/orders/[id]/close/route.ts
@@ -4,15 +4,16 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 
 export async function POST(_: Request, { params }: { params: { id: string } }) {
   const supabase = createRouteHandlerClient({ cookies });
-  const { data:{ user } } = await supabase.auth.getUser();
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
   const { data, error } = await supabase
     .from('orders')
-    .update({ status: 'COMPLETED', closed_at: new Date().toISOString() })
+    .update({ status: 'COMPLETED', completed_at: new Date().toISOString() })
     .eq('id', params.id)
-    .neq('status','CANCELLED')
-    .select().single();
+    .neq('status', 'CANCELLED')
+    .select()
+    .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
   return NextResponse.json({ order: data });


### PR DESCRIPTION
## Summary
- update order close route to record `completed_at` when marking an order as COMPLETED

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c542abf5ec832d906c65df93f20a28