### PR TITLE
Use cta color and refresh tailwind config

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,9 +22,7 @@ body { @apply bg-black text-white overflow-x-hidden touch-pan-y; }
 .btn { @apply rounded-2xl px-4 py-3 font-medium active:scale-[0.98] transition; }
 .btn-primary { @apply bg-white text-black hover:bg-zinc-100; }
 .btn-ghost { @apply bg-white/10 hover:bg-white/20; }
-/* мокрый асфальт */
-.btn-secondary { background-color: #2f3a44; color: #fff; }
-.btn-secondary:hover { filter: brightness(1.06); }
+.btn-secondary { @apply bg-cta text-white hover:brightness-110; }
 
 .label { @apply text-sm text-white/70 mb-1 block; }
 .input { @apply w-full rounded-2xl px-4 py-3 bg-white/10 border border-white/20 outline-none placeholder-white/40; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,22 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-content: [
-'./app/**/*.{ts,tsx}',
-'./components/**/*.{ts,tsx}',
-],
-theme: {
-extend: {
-colors: {
-grayGlass: 'rgba(30,30,35,0.55)',
-grayGlassStrong: 'rgba(30,30,35,0.75)',
-accent: '#E7A6C9',
-accent2: '#9EC5FF',
-},
-boxShadow: {
-glass: '0 10px 30px rgba(0,0,0,0.25)',
-},
-screens: { xs: '360px' },
-},
-},
-plugins: [],
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        grayGlass: 'rgba(30,30,35,0.55)',
+        grayGlassStrong: 'rgba(30,30,35,0.75)',
+        cta: '#5f5f5f', // wet asphalt
+      },
+      boxShadow: {
+        glass: '0 10px 30px rgba(0,0,0,0.25)',
+      },
+      screens: { xs: '360px' },
+    },
+  },
+  plugins: [],
 };
+


### PR DESCRIPTION
## Summary
- replace Tailwind config with gray glass and new `cta` accent
- restyle buttons to use `cta` color instead of pink

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c542ae4ee4832d8a6702f2380ef318