### PR TITLE
feat: fallback video background

### DIFF
--- a/app/api/video-bg/route.ts
+++ b/app/api/video-bg/route.ts
@@ -3,16 +3,33 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 // Возвращает { url, path } активного видеофона
 export async function GET() {
-  const supabase = supabaseServer();
+  try {
+    const supabase = supabaseServer();
 
-  const { data, error } = await supabase.from('active_background').select('*').limit(1).single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  if (!data?.storage_path) return NextResponse.json({ url: null });
+    const { data, error } = await supabase
+      .from('active_background')
+      .select('*')
+      .limit(1)
+      .single();
 
-  // пробуем подписанный URL, иначе — public
-  const signed = await supabase.storage.from('backgrounds').createSignedUrl(data.storage_path, 3600);
-  const url = signed.data?.signedUrl
-    ?? supabase.storage.from('backgrounds').getPublicUrl(data.storage_path).data.publicUrl;
+    if (!error && data?.storage_path) {
+      // пробуем подписанный URL, иначе — public
+      const signed = await supabase.storage
+        .from('backgrounds')
+        .createSignedUrl(data.storage_path, 3600);
+      const url =
+        signed.data?.signedUrl ??
+        supabase.storage
+          .from('backgrounds')
+          .getPublicUrl(data.storage_path).data.publicUrl;
 
-  return NextResponse.json({ url, path: data.storage_path });
+      return NextResponse.json({ url, path: data.storage_path });
+    }
+  } catch (e) {
+    // ignore and use fallback below
+    console.warn('video-bg fallback', e);
+  }
+
+  // Fallback: use bundled public video to avoid 500
+  return NextResponse.json({ url: '/bg.mp4', path: 'bg.mp4' });
 }


### PR DESCRIPTION
## Summary
- avoid 500 errors in video background endpoint by falling back to bundled file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c627f2f738832da4fb42a99fa7b3f8