### PR TITLE
fix: make bottom nav usable

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -2,7 +2,7 @@
 import { useOrder } from '@/lib/order-store';
 
 const items = [
-  { step: 'start', label: 'Главная' },
+  { step: 'home', label: 'Главная' },
   { step: 'start', label: 'Заказ' },
   { step: 'history', label: 'История' },
   { step: 'feedback', label: 'Отзыв' },
@@ -10,7 +10,7 @@ const items = [
 ];
 
 export default function BottomNav() {
-  const { setStep, openModal } = useOrder();
+  const { setStep, openModal, closeModal } = useOrder();
   return (
     <nav className="fixed bottom-3 left-0 right-0 z-40">
       <div className="mx-auto max-w-md px-3">
@@ -19,8 +19,13 @@ export default function BottomNav() {
             <button
               key={it.label}
               onClick={() => {
-                openModal();
-                setStep(it.step as any);
+                if (it.step === 'home') {
+                  setStep('start');
+                  closeModal();
+                } else {
+                  setStep(it.step as any);
+                  openModal();
+                }
               }}
               className="px-3 py-2 text-sm rounded-xl text-white/80 hover:text-white hover:bg-white/10"
             >

--- a/lib/order-store.ts
+++ b/lib/order-store.ts
@@ -45,12 +45,12 @@ const initialDraft: OrderDraft = {
 };
 
 export const useOrder = create<UIFlowState>((set) => ({
-  open: true,
+  open: false,
   step: 'start',
   draft: initialDraft,
   openModal: () => set({ open: true }),
   closeModal: () => set({ open: false }),
   setStep: (s) => set({ step: s }),
   patchDraft: (p) => set((state) => ({ draft: { ...state.draft, ...p } })),
-  reset: () => set({ step: 'start', draft: initialDraft, open: true }),
+  reset: () => set({ step: 'start', draft: initialDraft, open: false }),
 }));


### PR DESCRIPTION
## Summary
- keep order modal closed by default
- allow bottom nav to close modal when returning home

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c629ca2e80832db137cc1434e3844d